### PR TITLE
Add support for external tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Golang SQL database driver for [Yandex ClickHouse](https://clickhouse.yandex/)
 * Round Robin load-balancing
 * Bulk write support :  `begin->prepare->(in loop exec)->commit`
 * LZ4 compression support (default to use pure go lz4, switch to use cgo lz4 by turn clz4 build tags on)
+* External Tables support
 
 ## DSN
 
@@ -185,6 +186,114 @@ func main() {
 
 	for _, item := range items {
 		log.Printf("country: %s, os: %d, browser: %d, categories: %v, action_time: %s", item.CountryCode, item.OsID, item.BrowserID, item.Categories, item.ActionTime)
+	}
+}
+```
+
+External tables support
+```go
+package main
+
+import (
+	"database/sql"
+    "database/sql/driver"
+	"fmt"
+    "github.com/ClickHouse/clickhouse-go/lib/column"
+	"log"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go"
+)
+
+func main() {
+	connect, err := sql.Open("clickhouse", "tcp://127.0.0.1:9000?debug=true")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := connect.Ping(); err != nil {
+		if exception, ok := err.(*clickhouse.Exception); ok {
+			fmt.Printf("[%d] %s \n%s\n", exception.Code, exception.Message, exception.StackTrace)
+		} else {
+			fmt.Println(err)
+		}
+		return
+	}
+
+	_, err = connect.Exec(`
+		CREATE TABLE IF NOT EXISTS example (
+			country_code FixedString(2),
+			os_id        UInt8,
+			browser_id   UInt8,
+			categories   Array(Int16),
+			action_day   Date,
+			action_time  DateTime
+		) engine=Memory
+	`)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	var (
+		tx, _   = connect.Begin()
+		stmt, _ = tx.Prepare("INSERT INTO example (country_code, os_id, browser_id, categories, action_day, action_time) VALUES (?, ?, ?, ?, ?, ?)")
+	)
+	defer stmt.Close()
+
+	for i := 0; i < 100; i++ {
+		if _, err := stmt.Exec(
+			"RU",
+			10+i,
+			100+i,
+			clickhouse.Array([]int16{1, 2, 3}),
+			time.Now(),
+			time.Now(),
+		); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		log.Fatal(err)
+	}
+
+	col, err := column.Factory("country_code", "String", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	countriesExternalTable := clickhouse.ExternalTable{
+		Name: "countries",
+		Values: [][]driver.Value{
+			{"RU"},
+		},
+		Columns: []column.Column{col},
+	}
+	
+    rows, err := connect.Query("SELECT country_code, os_id, browser_id, categories, action_day, action_time "+
+            "FROM example WHERE country_code IN ?", countriesExternalTable)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			country               string
+			os, browser           uint8
+			categories            []int16
+			actionDay, actionTime time.Time
+		)
+		if err := rows.Scan(&country, &os, &browser, &categories, &actionDay, &actionTime); err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("country: %s, os: %d, browser: %d, categories: %v, action_day: %s, action_time: %s", country, os, browser, categories, actionDay, actionTime)
+	}
+
+	if err := rows.Err(); err != nil {
+		log.Fatal(err)
+	}
+
+	if _, err := connect.Exec("DROP TABLE example"); err != nil {
+		log.Fatal(err)
 	}
 }
 ```

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -26,6 +26,12 @@ type (
 	UUID     = types.UUID
 )
 
+type ExternalTable struct {
+	Name    string
+	Values  [][]driver.Value
+	Columns []column.Column
+}
+
 var (
 	ErrInsertInNotBatchMode = errors.New("insert statement supported only in the batch mode (use begin/commit)")
 	ErrLimitDataRequestInTx = errors.New("data request has already been prepared in transaction")
@@ -82,7 +88,7 @@ func (ch *clickhouse) prepareContext(ctx context.Context, query string) (driver.
 }
 
 func (ch *clickhouse) insert(query string) (_ driver.Stmt, err error) {
-	if err := ch.sendQuery(splitInsertRe.Split(query, -1)[0] + " VALUES "); err != nil {
+	if err := ch.sendQuery(splitInsertRe.Split(query, -1)[0]+" VALUES ", nil); err != nil {
 		return nil, err
 	}
 	if ch.block, err = ch.readMeta(); err != nil {
@@ -142,11 +148,11 @@ func (ch *clickhouse) Commit() error {
 		return driver.ErrBadConn
 	}
 	if ch.block != nil {
-		if err := ch.writeBlock(ch.block); err != nil {
+		if err := ch.writeBlock(ch.block, ""); err != nil {
 			return err
 		}
 		// Send empty block as marker of end of data.
-		if err := ch.writeBlock(&data.Block{}); err != nil {
+		if err := ch.writeBlock(&data.Block{}, ""); err != nil {
 			return err
 		}
 		if err := ch.encoder.Flush(); err != nil {
@@ -173,7 +179,7 @@ func (ch *clickhouse) Rollback() error {
 
 func (ch *clickhouse) CheckNamedValue(nv *driver.NamedValue) error {
 	switch nv.Value.(type) {
-	case column.IP, column.UUID:
+	case ExternalTable, column.IP, column.UUID:
 		return nil
 	case nil, []byte, int8, int16, int32, int64, uint8, uint16, uint32, uint64, float32, float64, string, time.Time:
 		return nil

--- a/clickhouse_send_external_data.go
+++ b/clickhouse_send_external_data.go
@@ -1,0 +1,35 @@
+package clickhouse
+
+import "github.com/ClickHouse/clickhouse-go/lib/data"
+
+func (ch *clickhouse) sendExternalTables(externalTables []ExternalTable) error {
+	ch.logf("[send external tables] count %d", len(externalTables))
+	if externalTables == nil || len(externalTables) == 0 {
+		return nil
+	}
+	block := &data.Block{}
+	sentTables := make(map[string]bool, 0)
+	for _, externalTable := range externalTables {
+		if _, ok := sentTables[externalTable.Name]; ok {
+			continue
+		}
+		ch.logf("[send external table] name %s", externalTable.Name)
+		sentTables[externalTable.Name] = true
+		block.Columns = externalTable.Columns
+		block.NumColumns = uint64(len(externalTable.Columns))
+		for _, row := range externalTable.Values {
+			err := block.AppendRow(row)
+			if err != nil {
+				return err
+			}
+		}
+		if err := ch.writeBlock(block, externalTable.Name); err != nil {
+			return err
+		}
+		if err := ch.encoder.Flush(); err != nil {
+			return err
+		}
+		block.Reset()
+	}
+	return nil
+}

--- a/clickhouse_send_query.go
+++ b/clickhouse_send_query.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/lib/protocol"
 )
 
-func (ch *clickhouse) sendQuery(query string) error {
+func (ch *clickhouse) sendQuery(query string, externalTables []ExternalTable) error {
 	ch.logf("[send query] %s", query)
 	if err := ch.encoder.Uvarint(protocol.ClientQuery); err != nil {
 		return err
@@ -53,7 +53,10 @@ func (ch *clickhouse) sendQuery(query string) error {
 	if err := ch.encoder.String(query); err != nil {
 		return err
 	}
-	if err := ch.writeBlock(&data.Block{}); err != nil {
+	if err := ch.sendExternalTables(externalTables); err != nil {
+		return err
+	}
+	if err := ch.writeBlock(&data.Block{}, ""); err != nil {
 		return err
 	}
 	return ch.encoder.Flush()

--- a/clickhouse_write_block.go
+++ b/clickhouse_write_block.go
@@ -5,14 +5,14 @@ import (
 	"github.com/ClickHouse/clickhouse-go/lib/protocol"
 )
 
-func (ch *clickhouse) writeBlock(block *data.Block) error {
+func (ch *clickhouse) writeBlock(block *data.Block, tableName string) error {
 	ch.Lock()
 	defer ch.Unlock()
 	if err := ch.encoder.Uvarint(protocol.ClientData); err != nil {
 		return err
 	}
 
-	if err := ch.encoder.String(""); err != nil { // temporary table
+	if err := ch.encoder.String(tableName); err != nil { // temporary table
 		return err
 	}
 

--- a/examples/external_data.go
+++ b/examples/external_data.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"github.com/ClickHouse/clickhouse-go/lib/column"
+	"log"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go"
+)
+
+func main() {
+	connect, err := sql.Open("clickhouse", "tcp://127.0.0.1:9000?username=&compress=true&debug=true")
+	checkErr(err)
+	if err := connect.Ping(); err != nil {
+		if exception, ok := err.(*clickhouse.Exception); ok {
+			fmt.Printf("[%d] %s \n%s\n", exception.Code, exception.Message, exception.StackTrace)
+		} else {
+			fmt.Println(err)
+		}
+		return
+	}
+
+	_, err = connect.Exec(`
+		CREATE TABLE IF NOT EXISTS example (
+			country_code FixedString(2),
+			os_id        UInt8,
+			browser_id   UInt8,
+			categories   Array(Int16),
+			action_day   Date,
+			action_time  DateTime
+		) engine=Memory
+	`)
+
+	checkErr(err)
+	tx, err := connect.Begin()
+	checkErr(err)
+	stmt, err := tx.Prepare("INSERT INTO example (country_code, os_id, browser_id, categories, action_day, action_time) VALUES (?, ?, ?, ?, ?, ?)")
+	checkErr(err)
+
+	for i := 0; i < 100; i++ {
+		if _, err := stmt.Exec(
+			"RU",
+			10+i,
+			100+i,
+			[]int16{1, 2, 3},
+			time.Now(),
+			time.Now(),
+		); err != nil {
+			log.Fatal(err)
+		}
+	}
+	checkErr(tx.Commit())
+
+	col, err := column.Factory("country_code", "String", nil)
+	checkErr(err)
+	countriesExternalTable := clickhouse.ExternalTable{
+		Name: "countries",
+		Values: [][]driver.Value{
+			{"RU"},
+		},
+		Columns: []column.Column{col},
+	}
+
+	rows, err := connect.Query("SELECT country_code, os_id, browser_id, categories, action_day, action_time "+
+		"FROM example WHERE country_code IN ?", countriesExternalTable)
+	checkErr(err)
+	for rows.Next() {
+		var (
+			country               string
+			os, browser           uint8
+			categories            []int16
+			actionDay, actionTime time.Time
+		)
+		checkErr(rows.Scan(&country, &os, &browser, &categories, &actionDay, &actionTime))
+		log.Printf("country: %s, os: %d, browser: %d, categories: %v, action_day: %s, action_time: %s", country, os, browser, categories, actionDay, actionTime)
+	}
+
+	if _, err := connect.Exec("DROP TABLE example"); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func checkErr(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/helpers.go
+++ b/helpers.go
@@ -22,6 +22,7 @@ func numInput(query string) int {
 		like          = newMatcher("like")
 		limit         = newMatcher("limit")
 		between       = newMatcher("between")
+		in            = newMatcher("in")
 		and           = newMatcher("and")
 	)
 	for {
@@ -58,7 +59,7 @@ func numInput(query string) int {
 				char == '[':
 				keyword = true
 			default:
-				if limit.matchRune(char) || like.matchRune(char) {
+				if limit.matchRune(char) || like.matchRune(char) || in.matchRune(char) {
 					keyword = true
 				} else if between.matchRune(char) {
 					keyword = true

--- a/stmt.go
+++ b/stmt.go
@@ -49,7 +49,7 @@ func (stmt *stmt) execContext(ctx context.Context, args []driver.Value) (driver.
 		}
 		if (stmt.counter % stmt.ch.blockSize) == 0 {
 			stmt.ch.logf("[exec] flush block")
-			if err := stmt.ch.writeBlock(stmt.ch.block); err != nil {
+			if err := stmt.ch.writeBlock(stmt.ch.block, ""); err != nil {
 				return nil, err
 			}
 			if err := stmt.ch.encoder.Flush(); err != nil {
@@ -102,16 +102,18 @@ func (stmt *stmt) Close() error {
 	return nil
 }
 
-func (stmt *stmt) bind(args []driver.NamedValue) string {
+func (stmt *stmt) bind(args []driver.NamedValue) (string, []ExternalTable) {
 	var (
-		buf       bytes.Buffer
-		index     int
-		keyword   bool
-		inBetween bool
-		like      = newMatcher("like")
-		limit     = newMatcher("limit")
-		between   = newMatcher("between")
-		and       = newMatcher("and")
+		buf            bytes.Buffer
+		index          int
+		keyword        bool
+		inBetween      bool
+		like           = newMatcher("like")
+		limit          = newMatcher("limit")
+		between        = newMatcher("between")
+		and            = newMatcher("and")
+		in             = newMatcher("in")
+		externalTables = make([]ExternalTable, 0)
 	)
 	switch {
 	case stmt.NumInput() != 0:
@@ -123,13 +125,25 @@ func (stmt *stmt) bind(args []driver.NamedValue) string {
 					if param := paramParser(reader); len(param) != 0 {
 						for _, v := range args {
 							if len(v.Name) != 0 && v.Name == param {
-								buf.WriteString(quote(v.Value))
+								switch v := v.Value.(type) {
+								case ExternalTable:
+									buf.WriteString(v.Name)
+									externalTables = append(externalTables, v)
+								default:
+									buf.WriteString(quote(v))
+								}
 							}
 						}
 					}
 				case '?':
 					if keyword && index < len(args) && len(args[index].Name) == 0 {
-						buf.WriteString(quote(args[index].Value))
+						switch v := args[index].Value.(type) {
+						case ExternalTable:
+							buf.WriteString(v.Name)
+							externalTables = append(externalTables, v)
+						default:
+							buf.WriteString(quote(v))
+						}
 						index++
 					} else {
 						buf.WriteRune(char)
@@ -149,7 +163,7 @@ func (stmt *stmt) bind(args []driver.NamedValue) string {
 						char == '[':
 						keyword = true
 					default:
-						if limit.matchRune(char) || like.matchRune(char) {
+						if limit.matchRune(char) || like.matchRune(char) || in.matchRune(char) {
 							keyword = true
 						} else if between.matchRune(char) {
 							keyword = true
@@ -170,7 +184,7 @@ func (stmt *stmt) bind(args []driver.NamedValue) string {
 	default:
 		buf.WriteString(stmt.query)
 	}
-	return buf.String()
+	return buf.String(), externalTables
 }
 
 func convertOldArgs(args []driver.Value) []driver.NamedValue {

--- a/write_column.go
+++ b/write_column.go
@@ -50,5 +50,5 @@ func (ch *clickhouse) WriteBlock(block *data.Block) error {
 	if block == nil {
 		return sql.ErrTxDone
 	}
-	return ch.writeBlock(block)
+	return ch.writeBlock(block, "")
 }


### PR DESCRIPTION
Adding support for external tables to improve the performance of IN and NOT IN statements.

The external tables are passed as plain SQL args and then replaced by their names dynamically. Quick example:
```
col, _ := column.Factory("country_code", "String", nil)
countriesExternalTable := clickhouse.ExternalTable{
	Name: "countries",
	Values: [][]driver.Value{
		{"RU"},
	},
	Columns: []column.Column{col},
}
	
rows, err := connect.Query("SELECT country_code, os_id, browser_id, categories, action_day, action_time "+
        "FROM example WHERE country_code IN ?", countriesExternalTable)
```
Added tests and updated the README and examples